### PR TITLE
Add parts_to_exclude and tests.py

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,88 @@
+# Test cases for xml_measure_counter
+
+import unittest
+from unittest.mock import MagicMock
+import xml_measure_counter
+import music21
+import tkinter as tk
+
+class TestXMLMeasureCounter(unittest.TestCase):
+    def setUp(self):
+        self.root = tk.Tk()
+        self.root.withdraw()
+        self.app = xml_measure_counter.App(self.root)
+
+    def tearDown(self):
+        self.root.destroy()
+
+    def test_reset(self):
+        self.app.total_measures = 10
+        self.app.reset()
+        self.assertEqual(self.app.total_measures, 0)
+
+    def test_get_total_measures(self):
+        score = music21.stream.Score()
+        part = music21.stream.Part()
+        measure = music21.stream.Measure()
+        note = music21.note.Note(quarterLength=4)
+        measure.append(note)
+        part.append(measure)
+        score.append(part)
+        self.assertEqual(self.app.get_total_measures(score), 1)
+
+    def test_get_total_measures_no_measures(self):
+        score = music21.stream.Score()
+        part = music21.stream.Part()
+        score.append(part)
+        self.assertEqual(self.app.get_total_measures(score), 0)
+
+    def test_get_total_measures_duration_proportion_not_1(self):
+        score = music21.stream.Score()
+        part = music21.stream.Part()
+        measure = music21.stream.Measure()
+        measure.barDurationProportion = MagicMock(return_value=0.5)
+        part.append(measure)
+        score.append(part)
+        self.assertEqual(self.app.get_total_measures(score), 0)
+
+    def test_get_total_measures_multiple_parts(self):
+        score = music21.stream.Score()
+        part1 = music21.stream.Part()
+        measure1 = music21.stream.Measure()
+        note1 = music21.note.Note(quarterLength=4)
+        measure1.append(note1)
+        measure2 = music21.stream.Measure()
+        measure2.append(note1)
+        part1.append(measure1)
+        part1.append(measure2)
+        part2 = music21.stream.Part()
+        measure3 = music21.stream.Measure()
+        measure3.append(note1)
+        part2.append(measure3)
+        score.append(part1)
+        score.append(part2)
+        self.assertEqual(self.app.get_total_measures(score), 3)
+
+    def test_parse_parts_to_exclude(self):
+        self.assertEqual(self.app.parse_parts_to_exclude("Violin , Piano"), {"Violin", "Piano"})
+
+    def test_get_total_measures_excluded_part(self):
+        score = music21.stream.Score()
+        part1 = music21.stream.Part()
+        part1.partName = "Violin"
+        measure1 = music21.stream.Measure()
+        note1 = music21.note.Note(quarterLength=4)
+        measure1.append(note1)
+        part1.append(measure1)
+        part2 = music21.stream.Part()
+        part2.partName = "Piano"
+        measure2 = music21.stream.Measure()
+        measure2.append(note1)
+        part2.append(measure2)
+        score.append(part1)
+        score.append(part2)
+        self.app.parts_to_exclude.set("Violin")
+        self.assertEqual(self.app.get_total_measures(score), 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/xml_measure_counter.py
+++ b/xml_measure_counter.py
@@ -15,33 +15,38 @@ class App:
         tk.Label(self.master, text="Folder path:").grid(row=0, column=0, sticky="W")
         self.folder_path = tk.StringVar()
         tk.Entry(self.master, textvariable=self.folder_path, width=50).grid(row=1, column=0, padx=10, pady=5)
+
+        # Parts to exclude label and textbox
+        tk.Label(self.master, text="Part names to exclude (separated by commas):").grid(row=2, column=0, sticky="W")
+        self.parts_to_exclude = tk.StringVar()
+        tk.Entry(self.master, textvariable=self.parts_to_exclude, width=50).grid(row=3, column=0, padx=10, pady=5)
         
         # Browse button
         tk.Button(self.master, text="Browse...", command=self.browse_folder).grid(row=1, column=1, padx=10, pady=5)
         
         # Process button
-        tk.Button(self.master, text="Process", command=self.process_files).grid(row=2, column=0, padx=10, pady=5)
+        tk.Button(self.master, text="Process", command=self.process_files).grid(row=4, column=0, padx=10, pady=5)
         
         # Reset button
         tk.Button(self.master, text="Reset", command=self.reset).grid(row=2, column=1, padx=10, pady=5)
-        
+
         # Status label
         self.status_label = tk.Label(self.master, text="")
-        self.status_label.grid(row=3, column=0, padx=10, pady=5)
+        self.status_label.grid(row=5, column=0, padx=10, pady=5)
         
         # Progress bar
         self.progress_bar = ttk.Progressbar(self.master, orient="horizontal", mode="determinate", maximum=100)
-        self.progress_bar.grid(row=4, column=0, padx=10, pady=5)
+        self.progress_bar.grid(row=6, column=0, padx=10, pady=5)
         self.progress_var = tk.DoubleVar()
         
         # Processed files counter
         self.processed_files_label = tk.Label(self.master, text="")
-        self.processed_files_label.grid(row=5, column=0, padx=10, pady=5)
+        self.processed_files_label.grid(row=7, column=0, padx=10, pady=5)
         self.file_count = 0
         
         # Total measures counter
         self.total_measures_label = tk.Label(self.master, text="")
-        self.total_measures_label.grid(row=6, column=0, padx=10, pady=5)
+        self.total_measures_label.grid(row=8, column=0, padx=10, pady=5)
         self.total_measures = 0
     
     def browse_folder(self):
@@ -108,10 +113,16 @@ class App:
         self.total_measures += total_measures
         self.total_measures_label.config(text=f"Total measures: {self.total_measures}")
     
+    def parse_parts_to_exclude(self, parts_to_exclude):
+        return set([part.strip() for part in parts_to_exclude.split(",")])
 
     def get_total_measures(self, score):
         total_measures = 0
+        exclude_parts = self.parse_parts_to_exclude(self.parts_to_exclude.get())
         for part in score.parts:
+            # match to partName rather than id to handle grouped staves (e.g. Piano)
+            if part.partName in exclude_parts:
+                continue
             for measure in part.getElementsByClass('Measure'):
                 if measure.barDurationProportion() != 1.0:
                     continue


### PR DESCRIPTION
- Added a textbox for entering part names to exclude separated by commas, stored in variable `parts_to_exclude`.
- Added method `parse_parts_to_exclude` to return a set of the unique part names entered.
- Implemented `parse_parts_to_exclude` within `get_total_measures`. While iterating through parts, if `part.partName` is in the `exclude_parts` set, continue to next part without counting measures.
- Matching by `part.partName` rather than `part.id` should handle cases of grouped staves, like Piano.
- Added `tests.py` with basic unit tests for some of the methods.
- `tests.py` can be extended with new edge cases to help define the app's expected behavior, e.g. parts with repeats.